### PR TITLE
cd: push tags

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,19 +5,30 @@ on:
     branches:
       - main
   workflow_dispatch:
-#  pull_request:
+  pull_request:
 
 jobs:
   push-executors:
     runs-on: ubuntu-latest
-    container:
-      image: jinaai/jina:master-standard
-      options: "--entrypoint /bin/bash"
     steps:
+      - name: install git
+        run: |
+          # checkout needs git >= 2.18 to check out repo as git repo and not archive
+          # repo is needed for getting tag
+          sudo apt-get update && sudo apt-get install -y git && sudo apt-get upgrade git
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Get previous tag
+        id: previoustag
+        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+        with:
+          fallback: ""
       - name: push to Hubble
         run: |
           bash ./.github/workflows/scripts/push.sh .
         env:
           token: ${{ secrets.GH_TOKEN }}
+          GIT_TAG: ${{ steps.previoustag.outputs.tag }}
+

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,17 +5,12 @@ on:
     branches:
       - main
   workflow_dispatch:
-  pull_request:
+#  pull_request:
 
 jobs:
   push-executors:
     runs-on: ubuntu-latest
     steps:
-      - name: install git
-        run: |
-          # checkout needs git >= 2.18 to check out repo as git repo and not archive
-          # repo is needed for getting tag
-          sudo apt-get update && sudo apt-get install -y git && sudo apt-get upgrade git
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           if [[ ! -f "Dockerfile" ]]; then
             docker run --entrypoint="normalizer" -v "$(pwd):/workspace" \
-            jinahub/hubble-normalizer:v0.1.0 . --jina-version=2
+            jinahub/hubble-normalizer:latest . --jina-version=2
             sudo chown -R $(id -u ${USER}):$(id -g ${USER}) . ; fi
       - name: Run unit tests
         run: pytest -s -v -m "not gpu"

--- a/.github/workflows/scripts/push.sh
+++ b/.github/workflows/scripts/push.sh
@@ -54,12 +54,12 @@ else
   jina hub pull jinahub+docker://$exec_name/$GIT_TAG
   exists=$?
   if [[ $exists == 1 ]]; then
-    echo does NOT exist, pushing
-    jina hub push --force $exec_uuid --secret $exec_secret . -t $GIT_TAG
+    echo does NOT exist, pushing to latest and $GIT_TAG
+    jina hub push --force $exec_uuid --secret $exec_secret . -t $GIT_TAG -t latest
   else
-    echo exists, will NOT push
+    echo exists, only push to latest
+    jina hub push --force $exec_uuid --secret $exec_secret .
   fi
 fi
 
 # we push to latest every time
-jina hub push --force $exec_uuid --secret $exec_secret .

--- a/.github/workflows/scripts/push.sh
+++ b/.github/workflows/scripts/push.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
-apt-get update && apt-get install -y jq curl
+sudo apt-get update && sudo apt-get install -y jq curl
+
+JINA_VERSION=$(curl -L -s "https://pypi.org/pypi/jina/json" \
+  |  jq  -r '.releases | keys | .[]
+    | select(contains("dev") | not)
+    | select(startswith("2."))' \
+  | sort -V | tail -1)
+pip install git+https://github.com/jina-ai/jina.git@v${JINA_VERSION}#egg=jina[standard]
 
 push_dir=$1
 
@@ -35,4 +42,24 @@ echo SECRET=`head -c 3 <(echo $exec_secret)`
 
 rm secrets.json
 
+# we only push to a tag once,
+# if it doesn't exist
+echo git tag = $GIT_TAG
+
+if [ -z "$GIT_TAG" ]
+then
+  echo WARNING, no git tag!
+else
+  echo git tag = $GIT_TAG
+  jina hub pull jinahub+docker://$exec_name/$GIT_TAG
+  exists=$?
+  if [[ $exists == 1 ]]; then
+    echo does NOT exist, pushing
+    jina hub push --force $exec_uuid --secret $exec_secret . -t $GIT_TAG
+  else
+    echo exists, will NOT push
+  fi
+fi
+
+# we push to latest every time
 jina hub push --force $exec_uuid --secret $exec_secret .

--- a/.github/workflows/scripts/push.sh
+++ b/.github/workflows/scripts/push.sh
@@ -61,5 +61,3 @@ else
     jina hub push --force $exec_uuid --secret $exec_secret .
   fi
 fi
-
-# we push to latest every time


### PR DESCRIPTION
Add a tag when pushing to Jina Hub.

It only pushes that version if the version doesn't exist.

What this means:

- once you have a version you want to release, make a new git tag : `git tag v0.X`, e.g.
- push tag `git push --tags`
- trigger workflow
- this will also push to `latest`

During CI/CD

- you will only push to `latest`
- if you add a new tag, it will push to that tag AND to `latest`