### PR TITLE
Revert "ci: add push ga for releases"

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,10 +4,8 @@ on:
   push:
     branches:
       - main
-    release:
-      types:
-        - created
   workflow_dispatch:
+#  pull_request:
 
 jobs:
   push-executors:


### PR DESCRIPTION
Reverts jina-ai/executor-simpleindexer#7
The `WyriHaximus/github-action-get-previous-tag@v1` can not get the newly created tag. 

https://github.com/jina-ai/executor-simpleindexer/runs/3642306447?check_suite_focus=true#step:3:3