### PR TITLE
feat: add dynamic parameters to match in search

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import Dict, Optional
 
 from jina import DocumentArray, Executor, requests
@@ -41,13 +42,16 @@ class SimpleIndexer(Executor):
     def search(
         self,
         docs: Optional['DocumentArray'] = None,
+        parameters: Optional[Dict] = None,
         **kwargs,
     ):
         """Perform a vector similarity search and retrieve the full Document match
 
         :param docs: the Documents to search with"""
-
-        docs.match(self._storage, **self._match_args)
+        match_args = deepcopy(self._match_args)
+        if parameters and 'match_args' in parameters:
+            match_args.update(parameters['match_args'])
+        docs.match(self._storage, **match_args)
 
     @requests(on='/delete')
     def delete(self, parameters: Dict, **kwargs):

--- a/executor.py
+++ b/executor.py
@@ -47,10 +47,12 @@ class SimpleIndexer(Executor):
     ):
         """Perform a vector similarity search and retrieve the full Document match
 
-        :param docs: the Documents to search with"""
+        :param docs: the Documents to search with
+        :param parameters: the runtime arguments to `DocumentArray`'s match function. They overwrite the original match_args arguments.
+        """
         match_args = deepcopy(self._match_args)
-        if parameters and 'match_args' in parameters:
-            match_args.update(parameters['match_args'])
+        if parameters:
+            match_args.update(parameters)
         docs.match(self._storage, **match_args)
 
     @requests(on='/delete')

--- a/tests/test_simple_indexer.py
+++ b/tests/test_simple_indexer.py
@@ -158,12 +158,12 @@ def test_search(tmpdir, metric, docs):
         assert search_docs[i].matches[0].id == f'doc{i + 1}'
         assert len(search_docs[i].matches) == len(docs)
 
-    # test search with top_k = 1
+    # test search with top_k/limit = 1
     indexer.search(search_docs, parameters={'match_args': {'limit': 1}})
     for i in range(len(docs)):
         assert len(search_docs[i].matches) == 1
 
-    # test search with deafult limit/topk again
+    # test search with default limit/top_k again
     # indexer._match_args should not change as a result of the previous operation
     # so expected length of matches should be the same as the first case
     indexer.search(search_docs)

--- a/tests/test_simple_indexer.py
+++ b/tests/test_simple_indexer.py
@@ -159,7 +159,7 @@ def test_search(tmpdir, metric, docs):
         assert len(search_docs[i].matches) == len(docs)
 
     # test search with top_k/limit = 1
-    indexer.search(search_docs, parameters={'match_args': {'limit': 1}})
+    indexer.search(search_docs, parameters={'limit': 1})
     for i in range(len(docs)):
         assert len(search_docs[i].matches) == 1
 

--- a/tests/test_simple_indexer.py
+++ b/tests/test_simple_indexer.py
@@ -156,6 +156,19 @@ def test_search(tmpdir, metric, docs):
     indexer.search(search_docs)
     for i in range(len(docs)):
         assert search_docs[i].matches[0].id == f'doc{i + 1}'
+        assert len(search_docs[i].matches) == len(docs)
+
+    # test search with top_k = 1
+    indexer.search(search_docs, parameters={'match_args': {'limit': 1}})
+    for i in range(len(docs)):
+        assert len(search_docs[i].matches) == 1
+
+    # test search with deafult limit/topk again
+    # indexer._match_args should not change as a result of the previous operation
+    # so expected length of matches should be the same as the first case
+    indexer.search(search_docs)
+    for i in range(len(docs)):
+        assert len(search_docs[i].matches) == len(docs)
 
     # test search from empty indexed docs
     shutil.rmtree(tmpdir)


### PR DESCRIPTION
This PR resolves #11 and adds dynamic parameters to the `match` operation on `search`. 