### PR TITLE
feat: improve constructor documentation

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -18,7 +18,7 @@ class SimpleIndexer(Executor):
     def __init__(
         self,
         match_args: Optional[Dict] = None,
-        key_length: Optional[int] = 64,
+        key_length: int = 64,
         override_storage_path: Optional[str] = None,
         **kwargs,
     ):

--- a/executor.py
+++ b/executor.py
@@ -19,21 +19,19 @@ class SimpleIndexer(Executor):
         self,
         match_args: Optional[Dict] = None,
         key_length: int = 64,
-        override_storage_path: Optional[str] = None,
         **kwargs,
     ):
         """
         Initializer function for the simple indexer
+
+        To specify storage path, use `workspace` attribute in executor `metas`
         :param match_args: the arguments to `DocumentArray`'s match function
-        :param override_storage_path: the `path` argument to `DocumentArrayMemmap`'s constructor
         :param key_length: the `key_length` keyword argument to `DocumentArrayMemmap`'s constructor
         """
         super().__init__(**kwargs)
 
         self._match_args = match_args or {}
-        self._storage = DocumentArrayMemmap(
-            override_storage_path or self.workspace, key_length = key_length
-        )
+        self._storage = DocumentArrayMemmap(self.workspace, key_length = key_length)
         self.logger = JinaLogger(self.metas.name)
 
     @requests(on='/index')

--- a/executor.py
+++ b/executor.py
@@ -18,17 +18,21 @@ class SimpleIndexer(Executor):
     def __init__(
         self,
         match_args: Optional[Dict] = None,
+        key_length: int = 64,
+        override_storage_path: str = None,
         **kwargs,
     ):
         """
         Initializer function for the simple indexer
         :param match_args: the arguments to `DocumentArray`'s match function
+        :param override_storage_path: the `path` argument to `DocumentArrayMemmap`'s match function
+        :param key_length: the `key_length` keyword argument to `DocumentArrayMemmap`'s constructor
         """
         super().__init__(**kwargs)
 
         self._match_args = match_args or {}
         self._storage = DocumentArrayMemmap(
-            self.workspace, key_length=kwargs.get('key_length', 64)
+            override_storage_path or self.workspace, key_length = key_length
         )
         self.logger = JinaLogger(self.metas.name)
 

--- a/executor.py
+++ b/executor.py
@@ -18,14 +18,14 @@ class SimpleIndexer(Executor):
     def __init__(
         self,
         match_args: Optional[Dict] = None,
-        key_length: int = 64,
-        override_storage_path: str = None,
+        key_length: Optional[int] = 64,
+        override_storage_path: Optional[str] = None,
         **kwargs,
     ):
         """
         Initializer function for the simple indexer
         :param match_args: the arguments to `DocumentArray`'s match function
-        :param override_storage_path: the `path` argument to `DocumentArrayMemmap`'s match function
+        :param override_storage_path: the `path` argument to `DocumentArrayMemmap`'s constructor
         :param key_length: the `key_length` keyword argument to `DocumentArrayMemmap`'s constructor
         """
         super().__init__(**kwargs)


### PR DESCRIPTION
Allow use_with params for `DocumentArrayMemmap`:
* key_length:  DocumentArrayMemmap(path, key_length=`key_length`)

Documents how to change the storage path.